### PR TITLE
Fix a typo in "writeLn"

### DIFF
--- a/src/Commands/ResolveCommand.php
+++ b/src/Commands/ResolveCommand.php
@@ -53,7 +53,7 @@ class ResolveCommand extends Command
             $confirmation = $this->confirmOverwrite($input, $output, $outputFile);
 
             if (! $confirmation) {
-                $output->writeLn("<info>Cancelling...</info>");
+                $output->writeln("<info>Cancelling...</info>");
 
                 return true;
             }


### PR DESCRIPTION
This commit fixes a trivial typo in "writeLn".