### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "tightenco/collect": "^5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\CertificateChain\Test;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     protected function assertFileContentsEqual($fileA, $fileB)
     {


### PR DESCRIPTION
As we support `PHP 7`, I've updated our suite of tests to `PHPUnit 6`.

PS: I won't apply [this](https://styleci.io/analyses/XaEZZk) StyleCI changes. There are not related to this PR.