### PR TITLE
Add support for Symfony/Console 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.0",
         "guzzlehttp/guzzle": "~5.3.1|~6.0",
         "phpseclib/phpseclib": "^2.0.4",
-        "symfony/console": "^3.2",
+        "symfony/console": "^3.2|^4.0",
         "tightenco/collect": "^5.3"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for Symfony/console 4.x.

It doesn't appear any changes are required to make it work besides from the change in `composer.json`. Tested it locally and it still works as it did before.