### PR TITLE
Restrict certificate loading to HTTP and HTTPS urls

### DIFF
--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -88,7 +88,7 @@ class Certificate
             throw CouldNotLoadCertificate::invalidCertificateUrl($url);
         }
 
-        return static::loadFromUrl();
+        return static::loadFromUrl($url);
     }
 
     public function hasParentInTrustChain(): bool

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -81,7 +81,14 @@ class Certificate
 
     public function fetchParentCertificate(): self
     {
-        return static::loadFromUrl($this->getParentCertificateUrl());
+        $url = $this->getParentCertificateUrl();
+        
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if ($scheme !== "http" && $scheme !== "https") {
+            throw CouldNotLoadCertificate::invalidCertificateUrl($url);
+        }
+
+        return static::loadFromUrl();
     }
 
     public function hasParentInTrustChain(): bool

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -4,8 +4,8 @@ namespace Spatie\CertificateChain;
 
 use phpseclib\File\ASN1;
 use phpseclib\File\X509;
-use Spatie\CertificateChain\Exceptions\CouldNotLoadCertificate;
 use Spatie\CertificateChain\Exceptions\CouldNotCreateCertificate;
+use Spatie\CertificateChain\Exceptions\CouldNotLoadCertificate;
 
 class Certificate
 {
@@ -84,7 +84,7 @@ class Certificate
         $url = $this->getParentCertificateUrl();
         
         $scheme = parse_url($url, PHP_URL_SCHEME);
-        if ($scheme !== "http" && $scheme !== "https") {
+        if ($scheme !== 'http' && $scheme !== 'https') {
             throw CouldNotLoadCertificate::invalidCertificateUrl($url);
         }
 

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -82,7 +82,7 @@ class Certificate
     public function fetchParentCertificate(): self
     {
         $url = $this->getParentCertificateUrl();
-        
+
         $scheme = parse_url($url, PHP_URL_SCHEME);
         if ($scheme !== 'http' && $scheme !== 'https') {
             throw CouldNotLoadCertificate::invalidCertificateUrl($url);

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -83,8 +83,10 @@ class Certificate
     {
         $url = $this->getParentCertificateUrl();
 
+        // Only allow for parent certificates to be read from HTTP and HTTPS URLs to 
+        // prevent local file inclusion vulnerabilities
         $scheme = parse_url($url, PHP_URL_SCHEME);
-        if ($scheme !== 'http' && $scheme !== 'https') {
+        if (! in_array($scheme, ['http', 'https'])) {
             throw CouldNotLoadCertificate::invalidCertificateUrl($url);
         }
 


### PR DESCRIPTION
Hi,

this change restricts loading of parent certificates to HTTP and HTTPS urls. 
A malicious certificate with custom parent URLs can currently cause the chain resolver to fetch arbitrary files from the system (e.g. /etc/passwd would be valid). 

The certificates luckly still have to be valid X509 which limits the danger of this vulnerability, but it should be fixed. 